### PR TITLE
fixed missing encoding setting analog to TLS-Attacker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@
         </plugins>
     </build>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>


### PR DESCRIPTION
I fixed the missing encoding setting error analog to the TLS-Attacker POM.

Thanks to @anelam 